### PR TITLE
Close navigation on route change (mobile)

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -39,7 +39,7 @@
           <NuxtLink
             :to="item.link"
             class="text-red-200 hover:text-white no-underline"
-            @click.prevent="toggleVisibility"
+            @click.native="toggleVisibility"
           >
             {{ item.name }}
           </NuxtLink>


### PR DESCRIPTION
The click event was not triggered.
I fixed it by adding the `native` modifier.

Closes #52 