### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -1,7 +1,7 @@
 import type { RouterConfig } from '@nuxt/schema'
 import type { RouterScrollBehavior, RouteLocationNormalized } from 'vue-router'
 import { nextTick } from 'vue'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 // @ts-ignore
 import { appPageTransition as defaultPageTransition } from '#build/nuxt.config.mjs'
 


### PR DESCRIPTION
hey 👋 

This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.

But then I know you know that 😆 